### PR TITLE
don't truncate after additional ...

### DIFF
--- a/lib/meta-marked.js
+++ b/lib/meta-marked.js
@@ -6,10 +6,17 @@ var yaml = require('js-yaml');
 
 // Splits the given string into a meta section and a markdown section if a meta section is present, else returns null
 function splitInput(str) {
-	var ellipsisSplit = str.split('\n...', 2);
-	return str.slice(0, 3) === '---' && ellipsisSplit.length > 1 ?
-		ellipsisSplit :
-		null;
+	if (str.substring(0, 3) !== '---') {
+		return null;
+	}
+
+	var idx = str.indexOf('\n...');
+
+	if (idx === -1) {
+		return null;
+	}
+
+	return [str.substring(0, idx+4), str.substring(idx+4)];
 }
 
 var metaMarked = function(src, opt, callback) {


### PR DESCRIPTION
Currently, if you have additional ... after the header it will be truncated.

Instead of using `split` we're using a slightly more explicit `indexOf` check.
