### PR TITLE
Retain provided markdown in output

### DIFF
--- a/lib/meta-marked.js
+++ b/lib/meta-marked.js
@@ -22,10 +22,12 @@ var metaMarked = function(src, opt, callback) {
 
 	return mySplitInput ?  {
 			meta : yaml.safeLoad(mySplitInput[0]),
-			html : marked(mySplitInput[1], opt, callback)
+			html : marked(mySplitInput[1], opt, callback),
+			markdown: mySplitInput[1]
 		} : {
 			meta : null,
-			html : marked(src, opt, callback)
+			html : marked(src, opt, callback),
+			markdown: src
 		};
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,7 @@ tape("meta-marked", function(t) {
 
 	t.ok(basicResult.meta, "result.meta exists");
 	t.ok(basicResult.html, "result.html exists");
+	t.ok(basicResult.markdown, "result.markdown exists");
 
 	t.equal(basicResult.html, marked(basicTestMD), "result.html matches the marked output");
 	t.deepEqual(basicResult.meta, {
@@ -19,6 +20,7 @@ tape("meta-marked", function(t) {
             "js/doMoreStuff.js"
         ]
     }, "result.meta matches the yml output");
+	t.equal(basicResult.markdown, basicTestMD, "result.markdown matches the markdown input");
 
 	t.equal(metaMarked.noMeta(basicTestMD), marked(basicTestMD), ".noMeta produces the same output as marked");
 


### PR DESCRIPTION
Retaining the input meta markdown is desirable for users which are
interested in both the meta data and the markdown in markdown format.

The markdown string is loaded in memory and returning it does not incur
any processing overhead.