### PR TITLE
Update image/link for david.dm.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## meta-marked
 #### The [marked](http://github.com/chjj/marked) markdown processor for Node.js with support for [YAML](http://yaml.org/) metadata
 
-![dependencies](https://david-dm.org/j201/meta-marked.png) 
+[![Dependency Status](https://david-dm.org/j201/meta-marked.svg)](https://david-dm.org/j201/meta-marked)
 
 Just a quick extension I needed for processing markdown in Node. Props to Christopher Jeffrey for his excellent markdown processor 'marked'.
 


### PR DESCRIPTION
I noticed that the david-dm.org dependency image in the readme wasn't a link, so I had to manually go to https://david-dm.org/j201/meta-marked to see which dependencies were out of date.

I updated the image to use the suggested markdown from https://david-dm.org/j201/meta-marked. It is now a link, and it uses svg instead of png.